### PR TITLE
Chore: .gitignoreにsecrets.tomlを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Thumbs.db
 *.sqlite3
 .env.local
 .credentials/
+.streamlit/secrets.toml
 
 # Reports
 coverage/


### PR DESCRIPTION
Streamlitのsecrets.tomlファイル（Google Sheets認証情報を含む）を
Gitリポジトリから除外するように設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)