### PR TITLE
Fix: Render Secret Filesからsecrets.tomlを読み込む機能を追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ gspread==6.0.0
 google-auth==2.32.0
 google-api-python-client==2.143.0
 requests==2.32.0
+toml==0.10.2
 
 # Development
 pytest==8.3.0

--- a/streamlit_app/utils/gsheet_helper.py
+++ b/streamlit_app/utils/gsheet_helper.py
@@ -28,6 +28,17 @@ def _load_service_account_info() -> dict[str, Any] | None:
         except Exception:  # noqa: BLE001
             st.warning("`gcp_service_account` secrets entry has unexpected format.")
 
+    # Try loading from Render Secret Files locations
+    for secret_path in ["/etc/secrets/secrets.toml", "secrets.toml"]:
+        if Path(secret_path).exists():
+            try:
+                import toml
+                secrets_data = toml.load(secret_path)
+                if "gcp_service_account" in secrets_data:
+                    return dict(secrets_data["gcp_service_account"])
+            except Exception:  # noqa: BLE001
+                pass
+
     raw_value = os.environ.get("GOOGLE_SERVICE_ACCOUNT_KEY")
     if not raw_value:
         path_hint = os.environ.get("GOOGLE_SERVICE_ACCOUNT_KEY_PATH")


### PR DESCRIPTION
- gsheet_helper.pyにSecret Filesの読み込みロジックを追加
- /etc/secrets/secrets.tomlとルートのsecrets.tomlをチェック
- toml==0.10.2を依存関係に追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)