### PR TITLE
Fix: Streamlit警告を非表示にし、デルタ表示から矢印を削除

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -48,9 +48,8 @@ def get_delta_display(value: float, format_type: str = "price") -> tuple[str, st
     if value == 0:
         return ("0円", "off") if format_type == "price" else ("0", "off")
     if value > 0:
-        return (f"{value:,.0f}円 ↑", "normal") if format_type == "price" else (f"{value:.1f} ↑", "normal")
-    abs_val = abs(value)
-    return (f"{abs_val:,.0f}円 ↓", "inverse") if format_type == "price" else (f"{abs_val:.1f} ↓", "inverse")
+        return (f"+{value:,.0f}円", "normal") if format_type == "price" else (f"+{value:.1f}", "normal")
+    return (f"{value:,.0f}円", "inverse") if format_type == "price" else (f"{value:.1f}", "inverse")
 
 
 st.set_page_config(page_title="投資信託ナビゲーター", page_icon="??", layout="wide")

--- a/streamlit_app/utils/gsheet_helper.py
+++ b/streamlit_app/utils/gsheet_helper.py
@@ -16,9 +16,13 @@ SCOPES: Iterable[str] = ("https://www.googleapis.com/auth/spreadsheets.readonly"
 
 
 def _load_service_account_info() -> dict[str, Any] | None:
-    # Try Streamlit secrets first
+    # Try Streamlit secrets first (suppress warning)
     try:
-        secret_payload = st.secrets.get("gcp_service_account")
+        if hasattr(st, 'secrets') and st.secrets._file_paths:
+            secret_payload = st.secrets.get("gcp_service_account")
+        else:
+            secret_payload = None
+
         if secret_payload:
             if isinstance(secret_payload, str):
                 try:


### PR DESCRIPTION
- st.secretsアクセス時の警告を抑制
- デルタ表示の矢印（↑↓）を削除し、+/-記号に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)