### PR TITLE
Perf: メモリ使用量を大幅に削減

### DIFF
--- a/streamlit_app/utils/chart_helper.py
+++ b/streamlit_app/utils/chart_helper.py
@@ -123,6 +123,11 @@ def create_price_chart(df: pd.DataFrame, show_indicators: Dict[str, bool] | None
     if show_indicators is None:
         show_indicators = {"移動平均線": True}
 
+    # メモリ削減：データポイント数を制限（500件以上の場合は間引き）
+    if len(df) > 500:
+        step = len(df) // 500
+        df = df.iloc[::step].copy()
+
     fig = make_subplots(
         rows=5,
         cols=1,
@@ -138,6 +143,7 @@ def create_price_chart(df: pd.DataFrame, show_indicators: Dict[str, bool] | None
             name="基準価額",
             line=dict(color="#1f77b4", width=2),
             connectgaps=True,
+            mode="lines",  # マーカーなしでメモリ削減
         ),
         row=1,
         col=1,

--- a/streamlit_app/utils/gsheet_helper.py
+++ b/streamlit_app/utils/gsheet_helper.py
@@ -118,9 +118,11 @@ def get_sheet_data(spreadsheet_id: str, sheet_name: str | None = None) -> list[s
 
         df = pd.DataFrame(processed_rows, columns=col_names)
         df["日付"] = pd.to_datetime(df["日付"], format="%Y/%m/%d", errors="coerce")
+
+        # メモリ最適化：float64からfloat32に変換
         for col in ("基準価額", "25日移動平均", "200日移動平均"):
             if col in df.columns:
-                df[col] = pd.to_numeric(df[col].astype(str).str.replace(",", ""), errors="coerce")
+                df[col] = pd.to_numeric(df[col].astype(str).str.replace(",", ""), errors="coerce").astype("float32")
 
         return df
     except Exception:


### PR DESCRIPTION
## 1. セッションステートの削減
- チャット履歴を最新10件に制限
- technical_data_per_fundを削除し、ローカル変数で管理
- 不要なセッションステート変数を削除

## 2. DataFrameのメモリ最適化
- float64からfloat32に変換（メモリ50%削減）
- 数値カラムの型を最適化

## 3. キャッシュのTTL短縮
- 3600秒（1時間）→1800秒（30分）に短縮
- メモリに保持される期間を削減

## 4. Plotlyチャートの軽量化
- データポイント数を500件に制限（間引き処理）
- mode="lines"を明示してマーカーを削除

期待効果：メモリ使用量 30-50% 削減

🤖 Generated with [Claude Code](https://claude.com/claude-code)