### PR TITLE
Fix: Streamlit Cloud対応 - st.secrets対応を追加

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -35,8 +35,15 @@ from utils.slack_notifier import (
     save_fund_status,
 )
 
+import os
+
 STORAGE_PATH = Path("previous_fund_status.json")
-SPREADSHEET_ID = "1O3nYKIHCrDbjz1yBGrrAnq883Lgotfvvq035tC9wMVM"
+
+# Get SPREADSHEET_ID from secrets or environment variable
+if hasattr(st, "secrets") and "GOOGLE_SPREADSHEET_ID" in st.secrets:
+    SPREADSHEET_ID = st.secrets["GOOGLE_SPREADSHEET_ID"]
+else:
+    SPREADSHEET_ID = os.environ.get("GOOGLE_SPREADSHEET_ID", "1O3nYKIHCrDbjz1yBGrrAnq883Lgotfvvq035tC9wMVM")
 
 
 def get_latest_valid_value(series: pd.Series, current_index: int) -> float | None:

--- a/streamlit_app/utils/gpt_analysis.py
+++ b/streamlit_app/utils/gpt_analysis.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
+import os
 from typing import Any, Dict, List
 
+import streamlit as st
 from openai import OpenAI
 
 
 def generate_personalized_analysis(technical_data: Dict[str, Any]) -> str:
     try:
-        client = OpenAI()
+        # Try Streamlit secrets first, fallback to environment variable
+        api_key = None
+        if hasattr(st, "secrets") and "OPENAI_API_KEY" in st.secrets:
+            api_key = st.secrets["OPENAI_API_KEY"]
+        if not api_key:
+            api_key = os.environ.get("OPENAI_API_KEY")
+
+        client = OpenAI(api_key=api_key)
         price_info = technical_data.get("price_info", "不明")
         rsi_info = technical_data.get("rsi_info", "不明")
         macd_info = technical_data.get("macd_info", "不明")
@@ -77,7 +86,14 @@ def generate_personalized_analysis(technical_data: Dict[str, Any]) -> str:
 
 def chat_with_ai_analyst(technical_data: Dict[str, Any], user_message: str, chat_history: List[Dict[str, str]] | None = None) -> str:
     try:
-        client = OpenAI()
+        # Try Streamlit secrets first, fallback to environment variable
+        api_key = None
+        if hasattr(st, "secrets") and "OPENAI_API_KEY" in st.secrets:
+            api_key = st.secrets["OPENAI_API_KEY"]
+        if not api_key:
+            api_key = os.environ.get("OPENAI_API_KEY")
+
+        client = OpenAI(api_key=api_key)
         system_context = f"""
 あなたは投資信託の分析に特化した金融アドバイザーです。
 以下のテクニカル指標データに基づいて、ユーザーの質問に答えてください。

--- a/streamlit_app/utils/gsheet_helper.py
+++ b/streamlit_app/utils/gsheet_helper.py
@@ -16,9 +16,15 @@ SCOPES: Iterable[str] = ("https://www.googleapis.com/auth/spreadsheets.readonly"
 
 
 def _load_service_account_info() -> dict[str, Any] | None:
-    # Streamlitのsecretsはスキップ（環境変数を優先）
-    # Try environment variable
-    raw_value = os.environ.get("GOOGLE_SERVICE_ACCOUNT_KEY")
+    # Try Streamlit secrets first (for Streamlit Cloud)
+    raw_value = None
+    if hasattr(st, "secrets") and "GOOGLE_SERVICE_ACCOUNT_KEY" in st.secrets:
+        raw_value = st.secrets["GOOGLE_SERVICE_ACCOUNT_KEY"]
+
+    # Fallback to environment variable (for Render/local)
+    if not raw_value:
+        raw_value = os.environ.get("GOOGLE_SERVICE_ACCOUNT_KEY")
+
     if not raw_value:
         path_hint = os.environ.get("GOOGLE_SERVICE_ACCOUNT_KEY_PATH")
         if path_hint:


### PR DESCRIPTION
- gsheet_helper.py: st.secretsを優先的に読み込み
- gpt_analysis.py: OpenAI APIキーをst.secretsから取得
- app.py: GOOGLE_SPREADSHEET_IDをst.secretsから取得
- RenderとStreamlit Cloudの両環境で動作可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)